### PR TITLE
update move prop section description

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,7 @@ evt object has same property as [Sortable onMove event](https://github.com/RubaX
  - `draggedContext`:  context linked to dragged element
  	- `index`: dragged element index
 	- `element`: dragged element underlying view model element
- - `futureIndex`:  Number. 
-    Potencial index of the dragged element if the drop operation is accepted.
+ 	- `futureIndex`:  potencial index of the dragged element if the drop operation is accepted
  - `relatedContext`: context linked to current drag operation
  	- `index`: target element index
 	- `element`: target element view model element


### PR DESCRIPTION
Change futureIndex indentation in README.md (move prop section) to mark that it's draggedContext property, not separate one