### PR TITLE
Add name property

### DIFF
--- a/src/vuedraggable.js
+++ b/src/vuedraggable.js
@@ -76,6 +76,8 @@
     }
 
     const draggableComponent = {
+      name: 'vuedraggable',
+
       props,
 
       data() {

--- a/src/vuedraggable.js
+++ b/src/vuedraggable.js
@@ -76,7 +76,7 @@
     }
 
     const draggableComponent = {
-      name: 'vuedraggable',
+      name: 'draggable',
 
       props,
 


### PR DESCRIPTION
When using Avoriaz to test vue components, it matches Vue objects based on the name property. Since Vue.Draggable didn't have one, I added it. Shouldn't influence anything, I think.