### PR TITLE
fix: destructuring error

### DIFF
--- a/src/vuedraggable.js
+++ b/src/vuedraggable.js
@@ -92,7 +92,7 @@
       },
 
       render(h) {
-        const slots = this.$slots.default
+        const slots = this.$slots.default || []
         if (slots && slots.length === 1) {
           const child = slots[0]
           if (child.componentOptions && child.componentOptions.tag === "transition-group") {


### PR DESCRIPTION
fix: `let children = [...slots]` in render function will be error, if list is empty.