### PR TITLE
Add getSortable Method

### DIFF
--- a/src/vuedraggable.js
+++ b/src/vuedraggable.js
@@ -249,6 +249,10 @@
           return this.$slots.default[0].componentInstance
         },
 
+        getSortable() {
+          return this._sortable
+        },
+
         resetTransitionData(index) {
           if (!this.noTransitionOnDrag || !this.transitionMode) {
             return


### PR DESCRIPTION
Leveraging the created `Sortable` instance is indeed useful, not only for accessing the instance's [methods](https://github.com/RubaXa/Sortable#method).

This PR only wrap accessing the `_sortable` object, into the `getSortable()` method, following the common conventions.

If it's a good idea, Should I include the `dist` files?