### PR TITLE
this._sortable undefined in beforeDestroy Hook

### DIFF
--- a/src/vuedraggable.js
+++ b/src/vuedraggable.js
@@ -128,7 +128,7 @@
       },
 
       beforeDestroy() {
-        this._sortable.destroy()
+        if(this._sortable !== null && this._sortable !== undefined) this._sortable.destroy();
       },
 
       computed: {

--- a/src/vuedraggable.js
+++ b/src/vuedraggable.js
@@ -128,7 +128,7 @@
       },
 
       beforeDestroy() {
-        if(this._sortable !== null && this._sortable !== undefined) this._sortable.destroy();
+        if(this._sortable !== undefined) this._sortable.destroy();
       },
 
       computed: {


### PR DESCRIPTION
There is an edge case in which this._sortable is undefined in the beforeDestroy Hook.
This edge case can be seen when unmaximizing the screen to a size in which elements will be re-ordered when using bootstrap grid than maximizing and then minimizing again, now the error shows.

This edit fixes this error but still after the first unmaximize after a refresh of the page the <draggable> element just disappears, still trying to find this issue