### PR TITLE
Added an inline drag handle example

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ Required: `false`
 Option used to initialize the sortable object see: [sortable option documentation](https://github.com/RubaXa/Sortable#options)<br>
 Note that all the method starting by "on" will be ignored as draggable component expose the same API via events.
 
+As an example, a drag handle can be added using this binding `:options="{handle:'.handle'}"`. Read the linked documentation for other options available to you.
+
 #### element
 Type: `String`<br>
 Default: `'div'`


### PR DESCRIPTION
I got caught into the same issue as #60 - thinking I'd make the small improvement with an inline example for a drag handle since it seems to be a common use case.