### PR TITLE
Ability to ignore a header slot

### DIFF
--- a/src/vuedraggable.js
+++ b/src/vuedraggable.js
@@ -246,7 +246,8 @@
         },
 
         updatePosition(oldIndex, newIndex) {
-          const updatePosition = list => list.splice(newIndex, 0, list.splice(oldIndex, 1)[0])
+          const headerLength = this.$slots.header.length;
+          const updatePosition = list => list.splice(newIndex - headerLength, 0, list.splice(oldIndex - headerLength, 1)[0])
           this.alterList(updatePosition)
         },
 


### PR DESCRIPTION
This change will allow this to work properly:

```
<draggable v-model="myList">
    <div slot="header">Ignored line</div>
    <div v-for="item in myList" :key="item">{{ item }}</div>
</draggable>
```