### PR TITLE
fix bug when options.group.pull is a function

### DIFF
--- a/src/vuedraggable.js
+++ b/src/vuedraggable.js
@@ -160,7 +160,8 @@
         },
 
         isCloning() {
-          return (!!this.options) && (!!this.options.group) && (this.options.group.pull === 'clone')
+          return (!!this.options && !!this.options.group && this.options.group.pull === 'clone')
+            || this._sortable.lastPullMode === 'clone';
         },
 
         realList() {


### PR DESCRIPTION
````
let options = {
                group: {
                    pull: (to, from) => {
                        if (['dimension', 'measure'].includes(to.options.group.name)) {
                            return 'move';
                        } else {
                            return 'clone';
                        }
                    },
                }
}
````
when i used it like this, it didn't work properly. this change  fixed it with `lastPullMode` attribute in object sortable.