### PR TITLE
Added `ignore` prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,14 @@ methods: {
     }
   }
 ```
+#### Ignore
+Type: `Array<String>`<br>
+Required: `false`<br>
+Default: `[]`<br>
+
+Array of HTML query selectors for elements that should be completely ignored by the component.
+The elements encompassed by these selectors will not be draggable, nor will they be indexed by the component.
+The selectors in this option will automatically be added to the SortableJS `filter` option.
 
 ### Events
 

--- a/README.md
+++ b/README.md
@@ -258,6 +258,18 @@ Array of HTML query selectors for elements that should be completely ignored by 
 The elements encompassed by these selectors will not be draggable, nor will they be indexed by the component.
 The selectors in this option will automatically be added to the SortableJS `filter` option.
 
+Example:
+```HTML
+<draggable v-model="list" :ignore="['.text']">
+   <div class="draggable-item">Item 1</div>
+   <div class="draggable-item">Item 2</div>
+   <div class="draggable-item">Item 3</div>
+   <div class="text">I am ignored</div>
+   <div class="draggable-item">Item 4</div>
+   <div class="draggable-item">Item 5</div>
+</draggable>
+```
+
 ### Events
 
 * Support for Sortable events:

--- a/src/vuedraggable.js
+++ b/src/vuedraggable.js
@@ -214,6 +214,10 @@
           const rawNodes = this.$slots.default
           return this.transitionMode ? rawNodes[0].child.$slots.default : (rawNodes ? rawNodes.filter(node => !this.isIgnoredElement(node.elm)) : rawNodes);
         },
+        
+        isIgnoredElement: function isIgnoredElement(elem) {
+          return !!(!elem.matches || this.ignore.filter(query => elem.matches(query)).length);
+        },
 
         computeIndexes() {
           this.$nextTick(() => {

--- a/src/vuedraggable.js
+++ b/src/vuedraggable.js
@@ -215,7 +215,7 @@
           return this.transitionMode ? rawNodes[0].child.$slots.default : (rawNodes ? rawNodes.filter(node => !this.isIgnoredElement(node.elm)) : rawNodes);
         },
         
-        isIgnoredElement: function isIgnoredElement(elem) {
+        isIgnoredElement(elem) {
           return !!(!elem.matches || this.ignore.filter(query => elem.matches(query)).length);
         },
 


### PR DESCRIPTION
I have added the `ignore` prop. This prop accepts an array of HTML query selectors (as strings) and will use those selectors to ignore any elements that match them in the list. This will make the elements undraggable, and will fix the issue where extra elements that were not in the `value` array were showing up as `undefined` when the `value` array was updated.
To make the element undraggable it adds the query selectors from the `ignore` prop to the SortableJS `filter` option.

This prop essentially gives the user the ability to have an element in their component that does not have a corresponding value in the `value` array, while not messing up the indexes or adding `undefined` to the `value` array when the dragging is finished, like would happen if the element wasn't included in this prop. Solves issue #488 