### PR TITLE
Make computeVmIndex() ignore HTML-Comments created by Vue.js

### DIFF
--- a/src/vuedraggable.js
+++ b/src/vuedraggable.js
@@ -27,7 +27,7 @@
     }
 
     function computeVmIndex(vnodes, element) {
-      return vnodes.map(elt => elt.elm).indexOf(element)
+      return vnodes.map(elt => elt.elm).filter(elt => !(elt instanceof Comment)).indexOf(element)
     }
 
     function computeIndexes(slots, children, isTransition) {


### PR DESCRIPTION
The `computeVmIndex()` function returns wrong indexes when the DOM contains HTML-Comments that were automatically created by Vue.js.

For example the DOM of my <Draggable> container looks like this:
![screenshot](https://screenshots.wichelmann.cloud/04-37-38-ef11798ba0769953936b9d187111bdb3.png)

These make `computeVmIndex()` return indexes that are out of range of the real entry-list, see:
https://github.com/SortableJS/Vue.Draggable/blob/master/src/vuedraggable.js#L215
and results in an `undefined` element being returned.