### PR TITLE
Support for TransitionGroup tag

### DIFF
--- a/src/vuedraggable.js
+++ b/src/vuedraggable.js
@@ -110,7 +110,7 @@
         const slots = this.$slots.default
         if (slots && slots.length === 1) {
           const child = slots[0]
-          if (child.componentOptions && child.componentOptions.tag === "transition-group") {
+          if (child.componentOptions && ["transition-group", "TransitionGroup"].includes(child.componentOptions.tag)) {
             this.transitionMode = true
           }
         }


### PR DESCRIPTION
According to [style guide](https://vuejs.org/v2/style-guide/#Component-name-casing-in-templates-strongly-recommended) :

> Component names should always be PascalCase in single-file components and string templates

Therefore `TransitionGroup` should be detected as `transition-group` component.