### PR TITLE
fix: lock to stable version of sortablejs

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test": "test"
   },
   "dependencies": {
-    "sortablejs": "^1.7.0"
+    "sortablejs": "1.7.0"
   },
   "devDependencies": {
     "babel-plugin-transform-object-assign": "^6.22.0",


### PR DESCRIPTION
Sortablejs as of 1.8.x introduced a bug that no longer allows dropping items into the empty areas of the draggable containers unless the new item is touching another item. Given that it's unexpected behavior and is not a "minor" update as the release version number would suggest, this will lock sortablejs down to a stable version that does not have this bug.

Addresses: #248