### PR TITLE
fix: group drag doesn't work

### DIFF
--- a/example/components/two-lists.vue
+++ b/example/components/two-lists.vue
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="col-3">
       <h3>Draggable 1</h3>
-      <draggable class="list-group" :list="list1" group="people" @change="log">
+      <draggable class="list-group" :list="list1" :options="{group="people"}" @change="log">
         <div
           class="list-group-item"
           v-for="(element, index) in list1"
@@ -15,7 +15,7 @@
 
     <div class="col-3">
       <h3>Draggable 2</h3>
-      <draggable class="list-group" :list="list2" group="people" @change="log">
+      <draggable class="list-group" :list="list2" :options="{group="people"}" @change="log">
         <div
           class="list-group-item"
           v-for="(element, index) in list2"


### PR DESCRIPTION
old version: group="people"
question: doesn't work

fix: :options="{group: 'people'}"

vue version: 2.9.6
vuedraggable: 2.18.1