### PR TITLE
update element to tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ https://david-desmaisons.github.io/draggable-example/
 * Compatible with Vue.js 2.0 transition-group
 * Cancellation support
 * Events reporting any changes when full control is needed
-* Reuse existing UI library components (such as [vuetify](https://vuetifyjs.com), [element](http://element.eleme.io/), or [vue material](https://vuematerial.io) etc...) and make them draggable using `element` and `componentData` props
+* Reuse existing UI library components (such as [vuetify](https://vuetifyjs.com), [element](http://element.eleme.io/), or [vue material](https://vuematerial.io) etc...) and make them draggable using `tag` and `componentData` props
 
 ## Backers
 


### PR DESCRIPTION
I think the prop is named different in newest release so I thought this should say `tag` instead of the old `element`. HTH