### PR TITLE
Add MIT license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "vuedraggable",
   "version": "2.20.0",
   "description": "draggable component for vue",
+  "license": "MIT",
   "main": "dist/vuedraggable.umd.min.js",
   "private": false,
   "scripts": {


### PR DESCRIPTION
This should make the license show up on npmjs.com