### PR TITLE
fix(import): avoid installing on global Vue if present on window

### DIFF
--- a/src/vuedraggable.js
+++ b/src/vuedraggable.js
@@ -478,8 +478,4 @@ const draggableComponent = {
   }
 };
 
-if (typeof window !== "undefined" && "Vue" in window) {
-  window.Vue.component("draggable", draggableComponent);
-}
-
 export default draggableComponent;


### PR DESCRIPTION
Proposal to avoid installing Vue.Draggable on global window.Vue.

Vue.Draggable should probably not make the assumption that if Vue is globally available (window), it should be installed on it. In some contexts, it's undesirable.

For example, as a developer of plugins for a given product, I want to isolate as much as possible my plugin from the other plugins available at runtime. That's why I ship my product embedding my own Vue & Vue.Draggable instance (not provided by the hosting product) and I don't expose it globally. However, I have no guarantee that other plugins will take the same precaution... In that case, Vue.Draggable will install itself in both and will result in undesired errors/warnings.

Vue proposes to install plugin through Vue.use, so, we should let the Vue.Draggable consumer deciding on which Vue instance he wants to install it, no ?