### PR TITLE
Fix Typescript export

### DIFF
--- a/src/vuedraggable.d.ts
+++ b/src/vuedraggable.d.ts
@@ -22,5 +22,5 @@ declare module 'vuedraggable' {
     value: any[];
   }
 
-  export = Draggable;
+  export default Draggable;
 }


### PR DESCRIPTION
Correct Typescript export which causes error when compiling

```
25:3 An export assignment cannot be used in a module with other exported elements.
    23 |   }
    24 | 
  > 25 |   export = Draggable;
       |   ^
    26 | }
    27 | 
Version: typescript 3.9.6
```