### PR TITLE
bump sortablejs 1.10.1 to 1.10.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "nested"
   ],
   "dependencies": {
-    "sortablejs": "^1.10.1"
+    "sortablejs": "^1.10.2"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "^3.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7636,9 +7636,10 @@ sort-keys@^1.0.0:
   dependencies:
     is-plain-obj "^1.0.0"
 
-sortablejs@^1.10.1:
+sortablejs@^1.10.2:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/sortablejs/-/sortablejs-1.10.2.tgz#6e40364d913f98b85a14f6678f92b5c1221f5290"
+  integrity sha512-YkPGufevysvfwn5rfdlGyrGjt7/CRHwvRPogD/lC+TnvcN29jDpCifKP+rBqf+LRldfXSTh+0CGLcSg0VIxq3A==
 
 source-list-map@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
to get the correction of this issue "Transform of dragged elements causes overlap of adjacent content" https://github.com/SortableJS/Sortable/issues/1644