### PR TITLE
Fix for issue #995: resolves Symbol.iterator error in Internet Explorer

### DIFF
--- a/src/vuedraggable.js
+++ b/src/vuedraggable.js
@@ -21,7 +21,7 @@ function computeIndexes(slots, children, isTransition, footerOffset) {
 
   const elmFromNodes = slots.map(elt => elt.elm);
   const footerIndex = children.length - footerOffset;
-  const rawIndexes = [...children].map((elt, idx) =>
+  const rawIndexes = Array.from(children).map((elt, idx) =>
     idx >= footerIndex ? elmFromNodes.length : elmFromNodes.indexOf(elt)
   );
   return isTransition ? rawIndexes.filter(ind => ind !== -1) : rawIndexes;


### PR DESCRIPTION
Hi,

This is a fix for issue #995.

HTMLCollections are not iterable as per DOM4 [spec](https://dom.spec.whatwg.org/#htmlcollection), and Internet Explorer will therefore log an error when attempting to spread `children`.

Replacing `[...children]` with `Array.from(children)` resolves the issue.