### PR TITLE
Add a missing property in the typescript typings

### DIFF
--- a/src/vuedraggable.d.ts
+++ b/src/vuedraggable.d.ts
@@ -29,6 +29,7 @@ declare module 'vuedraggable' {
     index: number;
     component: Vue;
     element: T;
+    list: T[];
   };
 
   export type Rectangle = {


### PR DESCRIPTION
This adds a `list` property on `DropContext`.