### PR TITLE
Integrate MultiDrag plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,12 +300,33 @@ methods: {
   }
 ```
 
+#### multiDrag
+Type: `boolean`<br>
+Required: `false`<br>
+Default: `false`<br>
+
+Set `true` for activate [MultiDrag](https://github.com/SortableJS/Sortable/wiki/Dragging-Multiple-Items-in-Sortable) plugin.
+
+#### multiDragKey
+Type: `string`<br>
+Required: `false`<br>
+Default: `undefined`<br>
+
+See "Selection key" part of [MultiDrag](https://github.com/SortableJS/Sortable/wiki/Dragging-Multiple-Items-in-Sortable) plugin.
+
+#### selectedClass
+Type: `string`<br>
+Required: `false`<br>
+Default: `sortable-selected` (from Sortable.js)<br>
+
+The selected class is the HTML class that will be applied to the selected elements in the list.
+
 ### Events
 
 * Support for Sortable events:
 
-  `start`, `add`, `remove`, `update`, `end`, `choose`, `unchoose`, `sort`, `filter`, `clone`<br>
-  Events are called whenever onStart, onAdd, onRemove, onUpdate, onEnd, onChoose, onUnchoose, onSort, onClone are fired by Sortable.js with the same argument.<br>
+  `start`, `add`, `remove`, `update`, `end`, `choose`, `unchoose`, `sort`, `filter`, `clone`, `select`, `deselect`<br>
+  Events are called whenever onStart, onAdd, onRemove, onUpdate, onEnd, onChoose, onUnchoose, onSort, onClone, onSelect, onDeselect are fired by Sortable.js with the same argument.<br>
   [See here for reference](https://github.com/RubaXa/Sortable#event-object-demo)
 
   Note that SortableJS OnMove callback is mapped with the [move prop](https://github.com/SortableJS/Vue.Draggable/blob/master/README.md#move)

--- a/example/components/multidrag.vue
+++ b/example/components/multidrag.vue
@@ -1,0 +1,102 @@
+<template>
+  <div class="row">
+    <div class="col-3">
+      <h3>Draggable 1</h3>
+      <draggable
+        class="list-group"
+        :list="list1"
+        group="people"
+        multi-drag
+        selected-class="selected"
+        @change="log"
+        @select="log"
+        @deselect="log"
+      >
+        <div
+          class="list-group-item"
+          v-for="(element, index) in list1"
+          :key="element.name"
+        >
+          {{ element.name }} {{ index }}
+        </div>
+      </draggable>
+    </div>
+
+    <div class="col-3">
+      <h3>Draggable 2</h3>
+      <draggable
+        class="list-group"
+        :list="list2"
+        group="people"
+        multi-drag
+        selected-class="selected"
+        @change="log"
+        @select="log"
+        @deselect="log"
+      >
+        <div
+          class="list-group-item"
+          v-for="(element, index) in list2"
+          :key="element.name"
+        >
+          {{ element.name }} {{ index }}
+        </div>
+      </draggable>
+    </div>
+
+    <rawDisplayer class="col-3" :value="list1" title="List 1" />
+
+    <rawDisplayer class="col-3" :value="list2" title="List 2" />
+  </div>
+</template>
+
+<style scoped>
+.selected {
+  color: red !important;
+  background-color: rgba(255, 0, 0, 0.2) !important;
+}
+</style>
+
+<script>
+import draggable from "@/vuedraggable";
+
+export default {
+  name: "multi-drag",
+  display: "Multi Drag",
+  order: 18,
+  components: {
+    draggable
+  },
+  data() {
+    return {
+      list1: [
+        { name: "John", id: 1 },
+        { name: "Joao", id: 2 },
+        { name: "Jean", id: 3 },
+        { name: "Gerard", id: 4 }
+      ],
+      list2: [
+        { name: "Juan", id: 5 },
+        { name: "Edgard", id: 6 },
+        { name: "Johnson", id: 7 }
+      ]
+    };
+  },
+  methods: {
+    add: function() {
+      this.list.push({ name: "Juan" });
+    },
+    replace: function() {
+      this.list = [{ name: "Edgard" }];
+    },
+    clone: function(el) {
+      return {
+        name: el.name + " cloned"
+      };
+    },
+    log: function(evt) {
+      window.console.log(evt);
+    }
+  }
+};
+</script>

--- a/src/vuedraggable.d.ts
+++ b/src/vuedraggable.d.ts
@@ -68,6 +68,10 @@ declare module 'vuedraggable' {
       tag?: string | null;
       move: any;
       componentData: any;
+      // plugin: multidrag
+      multiDrag?: boolean;
+      multiDragKey?: string;
+      selectedClass?: string;
     }
   >;
 

--- a/src/vuedraggable.js
+++ b/src/vuedraggable.js
@@ -414,7 +414,11 @@ const draggableComponent = {
       const updatePosition = list => {
         // get selected items with correct order
         // sort -> reverse (for prevent Array.splice side effect) -> splice -> reverse
-        const items = oldIndicies.sort().reverse().flatMap((oldIndex) => list.splice(oldIndex, 1)).reverse();
+        const items = oldIndicies
+          .sort()
+          .reverse()
+          .flatMap(oldIndex => list.splice(oldIndex, 1))
+          .reverse();
         return list.splice(newIndex, 0, ...items);
       };
       this.alterList(updatePosition);
@@ -459,7 +463,7 @@ const draggableComponent = {
 
     onDragStart(evt) {
       if (evt.items) {
-        this.multidragContexts = evt.items.map((e) => this.getUnderlyingVm(e));
+        this.multidragContexts = evt.items.map(e => this.getUnderlyingVm(e));
       }
       this.context = this.getUnderlyingVm(evt.item);
       evt.item._underlying_vm_ = this.clone(this.context.element);
@@ -494,12 +498,12 @@ const draggableComponent = {
 
     onDragUpdate(evt) {
       if (evt.items) {
-        const { newIndicies, oldIndicies, items, from } = evt;
-        const evts = items.map((item) => {
-          const oldIndex = oldIndicies.find((e) => e.multiDragElement === item).index;
-          const newIndex = newIndicies.find((e) => e.multiDragElement === item).index;
-          return { from, item, oldIndex, newIndex };
-        });
+        const { oldIndicies, items, from } = evt;
+        const evts = items.map(item => ({
+          from,
+          item,
+          oldIndex: oldIndicies.find(e => e.multiDragElement === item).index
+        }));
         this.onDragUpdateMulti(evt, evts, this.multidragContexts);
       } else {
         this.onDragUpdateSingle(evt);
@@ -508,27 +512,35 @@ const draggableComponent = {
 
     /**
      * @param {{newIndex: number}} originalEvent
-     * @param {{from: HTMLElement, item: HTMLElement, oldIndex: number, newIndex: number}[]} evts 
-     * @param {{index: number, element: any}[]} contexts 
+     * @param {{from: HTMLElement, item: HTMLElement, oldIndex: number, newIndex: number}[]} evts
+     * @param {{index: number, element: any}[]} contexts
      */
     onDragUpdateMulti(originalEvent, evts, contexts) {
       // for match item index and element index
       const elementIndexOffset = this.$slots.header.length || 0;
       // sort evts
       // note: "order by oldIndex asc" for prevent Node.insertBefore side effect
-      evts.sort(({ oldIndex: a }, { oldIndex: b }) => a - b)
+      evts.sort(({ oldIndex: a }, { oldIndex: b }) => a - b);
       // remove nodes
-      evts.forEach(({item}) => removeNode(item));
+      evts.forEach(({ item }) => removeNode(item));
       // insert nodes
-      evts.forEach(({from, item, oldIndex}) => insertNodeAt(from, item, oldIndex));
+      evts.forEach(({ from, item, oldIndex }) =>
+        insertNodeAt(from, item, oldIndex)
+      );
       // move items
-      const oldIndicies = evts.map(({ oldIndex }) => oldIndex - elementIndexOffset);
+      const oldIndicies = evts.map(
+        ({ oldIndex }) => oldIndex - elementIndexOffset
+      );
       const newIndex = this.getVmIndex(originalEvent.newIndex);
       this.updatePositions(oldIndicies, newIndex);
       // emit change
       oldIndicies.forEach((oldIndex, index) => {
-        const context = contexts.find((e) => e.index === oldIndex);
-        const moved = { element: context.element, oldIndex, newIndex: newIndex + index };
+        const context = contexts.find(e => e.index === oldIndex);
+        const moved = {
+          element: context.element,
+          oldIndex,
+          newIndex: newIndex + index
+        };
         this.emitChanges({ moved });
       });
     },

--- a/src/vuedraggable.js
+++ b/src/vuedraggable.js
@@ -102,7 +102,15 @@ function getComponentAttributes($attrs, componentData) {
 }
 
 const eventsListened = ["Start", "Add", "Remove", "Update", "End"];
-const eventsToEmit = ["Choose", "Unchoose", "Sort", "Filter", "Clone", "Select", "Deselect"];
+const eventsToEmit = [
+  "Choose",
+  "Unchoose",
+  "Sort",
+  "Filter",
+  "Clone",
+  "Select",
+  "Deselect"
+];
 const readonlyProperties = ["Move", ...eventsListened, ...eventsToEmit].map(
   evt => "on" + evt
 );
@@ -162,7 +170,7 @@ const props = {
     type: String,
     required: false,
     default: null
-  },
+  }
 };
 
 const draggableComponent = {

--- a/src/vuedraggable.js
+++ b/src/vuedraggable.js
@@ -102,7 +102,7 @@ function getComponentAttributes($attrs, componentData) {
 }
 
 const eventsListened = ["Start", "Add", "Remove", "Update", "End"];
-const eventsToEmit = ["Choose", "Unchoose", "Sort", "Filter", "Clone"];
+const eventsToEmit = ["Choose", "Unchoose", "Sort", "Filter", "Clone", "Select", "Deselect"];
 const readonlyProperties = ["Move", ...eventsListened, ...eventsToEmit].map(
   evt => "on" + evt
 );

--- a/tests/unit/vuedraggable.multidrag.spec.js
+++ b/tests/unit/vuedraggable.multidrag.spec.js
@@ -226,6 +226,10 @@ describe("draggable.vue with multidrag plugin", () => {
     let wrapper;
     /** @type {import("@vue/test-utils").WrapperArray<Vue>} */
     let wrapperItems;
+    /** @type {import("@vue/test-utils").Wrapper<Vue>} */
+    let item1;
+    /** @type {import("@vue/test-utils").Wrapper<Vue>} */
+    let item2;
     /** @type {Vue} */
     let vm;
     /** @type {jest.SpyInstance} */
@@ -268,11 +272,11 @@ describe("draggable.vue with multidrag plugin", () => {
       removeEventListenerMock.mockRestore();
     });
 
-    describe("should work", () => {
-      it("when drop first and second into last", async () => {
-        const item1 = wrapperItems.at(0);
-        const item2 = wrapperItems.at(1);
-  
+    describe("when drop first and second into last", () => {
+      beforeEach(async () => {
+        item1 = wrapperItems.at(0);
+        item2 = wrapperItems.at(1);
+
         // start drag from first item
         const startEvent = {
           item: item1.element,
@@ -301,19 +305,24 @@ describe("draggable.vue with multidrag plugin", () => {
         };
         onUpdate(updateEvent);
         await Vue.nextTick();
-
-        // check items order
-        expect(vm.list).toEqual(["c", "d", "a", "b"]);
-
-        // check emit event
-        const { start: startEmit, update: updateEmit } = wrapper.emitted();
-        expect(startEmit).not.toBeUndefined();
-        expect(updateEmit).not.toBeUndefined();
       });
 
-      it("when drop second and first into last", async () => {
-        const item1 = wrapperItems.at(0);
-        const item2 = wrapperItems.at(1);
+      it("should changed", () => {
+        expect(vm.list).toEqual(["c", "d", "a", "b"]);
+      });
+
+      it("should send events", () => {
+        const { start: startEmit, update: updateEmit, change: changeEmit } = wrapper.emitted();
+        expect(startEmit).toHaveLength(1);
+        expect(updateEmit).toHaveLength(1);
+        expect(changeEmit).toHaveLength(2);
+      });
+    });
+
+    describe("when drop second and first into last", () => {
+      beforeEach(async () => {
+        item1 = wrapperItems.at(0);
+        item2 = wrapperItems.at(1);
   
         // start drag from first item
         const startEvent = {
@@ -343,22 +352,26 @@ describe("draggable.vue with multidrag plugin", () => {
         };
         onUpdate(updateEvent);
         await Vue.nextTick();
-
-        // check items order
-        expect(vm.list).toEqual(["c", "d", "a", "b"]);
-
-        // check emit event
-        const { start: startEmit, update: updateEmit } = wrapper.emitted();
-        expect(startEmit).not.toBeUndefined();
-        expect(updateEmit).not.toBeUndefined();
       });
 
+      it("should changed", () => {
+        expect(vm.list).toEqual(["c", "d", "a", "b"]);
+      });
 
-      it("when drop second and last into first", async () => {
-        const item1 = wrapperItems.at(1);
-        const item2 = wrapperItems.at(3);
+      it("should send events", () => {
+        const { start: startEmit, update: updateEmit, change: changeEmit } = wrapper.emitted();
+        expect(startEmit).toHaveLength(1);
+        expect(updateEmit).toHaveLength(1);
+        expect(changeEmit).toHaveLength(2);
+      });
+    });
+
+    describe("when drop second and last into first", () => {
+      beforeEach(async () => {
+        item1 = wrapperItems.at(1);
+        item2 = wrapperItems.at(3);
   
-        // start drag from first item
+        // start drag from second item
         const startEvent = {
           item: item1.element,
           items: [item1.element, item2.element],
@@ -366,7 +379,7 @@ describe("draggable.vue with multidrag plugin", () => {
         onStart(startEvent);
         await Vue.nextTick();
 
-        // drop to last item
+        // drop to first item
         const updateEvent = {
           from: wrapper.element,
           newIndex: 1,
@@ -386,14 +399,17 @@ describe("draggable.vue with multidrag plugin", () => {
         };
         onUpdate(updateEvent);
         await Vue.nextTick();
+      });
 
-        // check items order
+      it("should changed", () => {
         expect(vm.list).toEqual(["b", "d", "a", "c"]);
+      });
 
-        // check emit event
-        const { start: startEmit, update: updateEmit } = wrapper.emitted();
-        expect(startEmit).not.toBeUndefined();
-        expect(updateEmit).not.toBeUndefined();
+      it("should send events", () => {
+        const { start: startEmit, update: updateEmit, change: changeEmit } = wrapper.emitted();
+        expect(startEmit).toHaveLength(1);
+        expect(updateEmit).toHaveLength(1);
+        expect(changeEmit).toHaveLength(2);
       });
     });
   });

--- a/tests/unit/vuedraggable.multidrag.spec.js
+++ b/tests/unit/vuedraggable.multidrag.spec.js
@@ -122,7 +122,9 @@ describe("draggable.vue with multidrag plugin", () => {
   });
 
   describe("item select and deselect", () => {
+    /** @type {import("@vue/test-utils").Wrapper<Vue>} */
     let wrapper;
+    /** @type {Vue} */
     let vm;
     /** @type {jest.SpyInstance} */
     let addEventListenerMock;
@@ -180,7 +182,9 @@ describe("draggable.vue with multidrag plugin", () => {
       expect(selectEmit).toHaveLength(2);
       const [[emitEvent1], [emitEvent2]] = selectEmit;
       expect(emitEvent1.items).toEqual([item1.element]);
+      expect(emitEvent1.newIndicies).toEqual([{ multiDragElement: item1.element, index: 1 }]);
       expect(emitEvent2.items).toEqual([item1.element, item2.element]);
+      expect(emitEvent2.newIndicies).toEqual([{ multiDragElement: item1.element, index: 1 }, { multiDragElement: item2.element, index: 4 }]);
     });
 
     it("should be deselected", async () => {
@@ -211,7 +215,9 @@ describe("draggable.vue with multidrag plugin", () => {
       expect(deselectEmit).toHaveLength(2);
       const [[emitEvent1], [emitEvent2]] = deselectEmit;
       expect(emitEvent1.items).toEqual([item2.element]);
+      expect(emitEvent1.newIndicies).toEqual([{ multiDragElement: item2.element, index: 4 }]);
       expect(emitEvent2.items).toEqual([]);
+      expect(emitEvent2.newIndicies).toEqual([]);
     });
   });
 });

--- a/tests/unit/vuedraggable.multidrag.spec.js
+++ b/tests/unit/vuedraggable.multidrag.spec.js
@@ -1,22 +1,20 @@
-import { mount, shallowMount } from "@vue/test-utils";
-import Sortable from "sortablejs";
+import { shallowMount } from '@vue/test-utils';
+import Sortable from 'sortablejs';
 
-import draggable from "@/vuedraggable";
-import Vue from "vue";
-import Fake from "./helper/FakeComponent.js";
-import FakeFunctional from "./helper/FakeFunctionalComponent.js";
+import draggable from '@/vuedraggable';
+import Vue from 'vue';
 
 function create(options) {
   const { propsData: { list: items = [] } } = options;
   const opts = Object.assign({
     attrs: {
-      sortableOption: "value",
-      "to-be-camelized": true,
+      sortableOption: 'value',
+      'to-be-camelized': true,
     },
     slots: {
       default: items.map((item) => `<div class="item">${item}</div>`),
-      header: "<header/>",
-      footer: "<footer/>",
+      header: '<header/>',
+      footer: '<footer/>',
     },
   }, options);
   const wrapper = shallowMount(draggable, opts);
@@ -26,7 +24,7 @@ function create(options) {
 }
 
 /**
- * @param {"addEventListener" | "removeEventListener"} listnerName 
+ * @param {'addEventListener' | 'removeEventListener'} listnerName 
  * @param {GlobalEventHandlers[listnerName]} callback 
  * @returns {jest.SpyInstance}
  */
@@ -39,8 +37,8 @@ function eventListnerDelegationMock(listnerName, callback) {
   });
 }
 
-describe("draggable.vue with multidrag plugin", () => {
-  describe("when initialized", () => {
+describe('draggable.vue with multidrag plugin', () => {
+  describe('when initialized', () => {
     const { error } = console;
     const { warn } = console;
 
@@ -54,8 +52,8 @@ describe("draggable.vue with multidrag plugin", () => {
       console.warn = warn;
     });
 
-    describe("with incorrect props", () => {
-      it("warns when multiDrag is true but selectedClass is not set", () => {
+    describe('with incorrect props', () => {
+      it('warns when multiDrag is true but selectedClass is not set', () => {
         shallowMount(draggable, {
           propsData: {
             multiDrag: true,
@@ -65,12 +63,12 @@ describe("draggable.vue with multidrag plugin", () => {
           },
         });
         expect(console.warn).toBeCalledWith(
-          "selected-class must be set when multi-drag mode. See https://github.com/SortableJS/Sortable/wiki/Dragging-Multiple-Items-in-Sortable#enable-multi-drag"
+          'selected-class must be set when multi-drag mode. See https://github.com/SortableJS/Sortable/wiki/Dragging-Multiple-Items-in-Sortable#enable-multi-drag'
         );
       });
     });
 
-    it("instantiate without error", () => {
+    it('instantiate without error', () => {
       const { wrapper } = create({
         propsData: {
           multiDrag: true,
@@ -82,7 +80,7 @@ describe("draggable.vue with multidrag plugin", () => {
     });
   });
 
-  describe("should have props", () => {
+  describe('should have props', () => {
     const { props } = create({
       propsData: {
         multiDrag: true,
@@ -92,7 +90,7 @@ describe("draggable.vue with multidrag plugin", () => {
 
     test.each([
       [
-        "multiDrag",
+        'multiDrag',
         {
           type: Boolean,
           required: false,
@@ -100,7 +98,7 @@ describe("draggable.vue with multidrag plugin", () => {
         },
       ],
       [
-        "multiDragKey",
+        'multiDragKey',
         {
           type: String,
           required: false,
@@ -108,21 +106,21 @@ describe("draggable.vue with multidrag plugin", () => {
         },
       ],
       [
-        "selectedClass",
+        'selectedClass',
         {
           type: String,
           required: false,
           default: null,
         },
       ],
-    ])("%s equal to %o", (name, value) => {
+    ])('%s equal to %o', (name, value) => {
       const propsValue = props[name];
       expect(propsValue).toEqual(value);
     });
   });
 
-  describe("item select and deselect", () => {
-    /** @type {import("@vue/test-utils").Wrapper<Vue>} */
+  describe('item select and deselect', () => {
+    /** @type {import('@vue/test-utils').Wrapper<Vue>} */
     let wrapper;
     /** @type {Vue} */
     let vm;
@@ -133,15 +131,15 @@ describe("draggable.vue with multidrag plugin", () => {
 
     beforeEach(() => {
       // event listener delegation hack
-      addEventListenerMock = eventListnerDelegationMock("addEventListener", (type, listener, options) => {
+      addEventListenerMock = eventListnerDelegationMock('addEventListener', (type, listener, options) => {
         wrapper?.element?.addEventListener(type, listener, options);
       });
-      removeEventListenerMock = eventListnerDelegationMock("removeEventListener", (type, listener, options) => {
+      removeEventListenerMock = eventListnerDelegationMock('removeEventListener', (type, listener, options) => {
         wrapper?.element?.removeEventListener(type, listener, options);
       });
 
       // component
-      const items = ["a", "b", "c", "d"];
+      const items = ['a', 'b', 'c', 'd'];
       const { wrapper: _w, vm: _v } = create({
         propsData: {
           list: items,
@@ -158,7 +156,7 @@ describe("draggable.vue with multidrag plugin", () => {
       removeEventListenerMock.mockRestore();
     });
 
-    it("should be selected", async () => {
+    it('should be selected', async () => {
       const wrapperItems = wrapper.findAll('.item');
       const item1 = wrapperItems.at(0);
       const item2 = wrapperItems.at(wrapperItems.length - 1);
@@ -187,7 +185,7 @@ describe("draggable.vue with multidrag plugin", () => {
       expect(emitEvent2.newIndicies).toEqual([{ multiDragElement: item1.element, index: 1 }, { multiDragElement: item2.element, index: 4 }]);
     });
 
-    it("should be deselected", async () => {
+    it('should be deselected', async () => {
       const wrapperItems = wrapper.findAll('.item');
       const item1 = wrapperItems.at(0);
       const item2 = wrapperItems.at(wrapperItems.length - 1);
@@ -221,14 +219,14 @@ describe("draggable.vue with multidrag plugin", () => {
     });
   });
 
-  describe("multi item drag and drop", () => {
-    /** @type {import("@vue/test-utils").Wrapper<Vue>} */
+  describe('multi item drag and drop', () => {
+    /** @type {import('@vue/test-utils').Wrapper<Vue>} */
     let wrapper;
-    /** @type {import("@vue/test-utils").WrapperArray<Vue>} */
+    /** @type {import('@vue/test-utils').WrapperArray<Vue>} */
     let wrapperItems;
-    /** @type {import("@vue/test-utils").Wrapper<Vue>} */
+    /** @type {import('@vue/test-utils').Wrapper<Vue>} */
     let item1;
-    /** @type {import("@vue/test-utils").Wrapper<Vue>} */
+    /** @type {import('@vue/test-utils').Wrapper<Vue>} */
     let item2;
     /** @type {Vue} */
     let vm;
@@ -247,15 +245,15 @@ describe("draggable.vue with multidrag plugin", () => {
 
     beforeEach(() => {
       // event listener delegation hack
-      addEventListenerMock = eventListnerDelegationMock("addEventListener", (type, listener, options) => {
+      addEventListenerMock = eventListnerDelegationMock('addEventListener', (type, listener, options) => {
         wrapper?.element?.addEventListener(type, listener, options);
       });
-      removeEventListenerMock = eventListnerDelegationMock("removeEventListener", (type, listener, options) => {
+      removeEventListenerMock = eventListnerDelegationMock('removeEventListener', (type, listener, options) => {
         wrapper?.element?.removeEventListener(type, listener, options);
       });
 
       // component
-      const items = ["a", "b", "c", "d"];
+      const items = ['a', 'b', 'c', 'd'];
       const { wrapper: _w, vm: _v } = create({
         propsData: {
           list: items,
@@ -278,7 +276,7 @@ describe("draggable.vue with multidrag plugin", () => {
       removeEventListenerMock.mockRestore();
     });
 
-    describe("when drop first and second into last", () => {
+    describe('when drop first and second into last', () => {
       beforeEach(async () => {
         item1 = wrapperItems.at(0);
         item2 = wrapperItems.at(1);
@@ -313,11 +311,11 @@ describe("draggable.vue with multidrag plugin", () => {
         await Vue.nextTick();
       });
 
-      it("should changed", () => {
-        expect(vm.list).toEqual(["c", "d", "a", "b"]);
+      it('should changed', () => {
+        expect(vm.list).toEqual(['c', 'd', 'a', 'b']);
       });
 
-      it("should send events", () => {
+      it('should send events', () => {
         const { start: startEmit, update: updateEmit, change: changeEmit } = wrapper.emitted();
         expect(startEmit).toHaveLength(1);
         expect(updateEmit).toHaveLength(1);
@@ -325,7 +323,7 @@ describe("draggable.vue with multidrag plugin", () => {
       });
     });
 
-    describe("when drop second and first into last", () => {
+    describe('when drop second and first into last', () => {
       beforeEach(async () => {
         item1 = wrapperItems.at(0);
         item2 = wrapperItems.at(1);
@@ -360,11 +358,11 @@ describe("draggable.vue with multidrag plugin", () => {
         await Vue.nextTick();
       });
 
-      it("should changed", () => {
-        expect(vm.list).toEqual(["c", "d", "a", "b"]);
+      it('should changed', () => {
+        expect(vm.list).toEqual(['c', 'd', 'a', 'b']);
       });
 
-      it("should send events", () => {
+      it('should send events', () => {
         const { start: startEmit, update: updateEmit, change: changeEmit } = wrapper.emitted();
         expect(startEmit).toHaveLength(1);
         expect(updateEmit).toHaveLength(1);
@@ -372,7 +370,7 @@ describe("draggable.vue with multidrag plugin", () => {
       });
     });
 
-    describe("when drop second and last into first", () => {
+    describe('when drop second and last into first', () => {
       beforeEach(async () => {
         item1 = wrapperItems.at(1);
         item2 = wrapperItems.at(3);
@@ -407,11 +405,11 @@ describe("draggable.vue with multidrag plugin", () => {
         await Vue.nextTick();
       });
 
-      it("should changed", () => {
-        expect(vm.list).toEqual(["b", "d", "a", "c"]);
+      it('should changed', () => {
+        expect(vm.list).toEqual(['b', 'd', 'a', 'c']);
       });
 
-      it("should send events", () => {
+      it('should send events', () => {
         const { start: startEmit, update: updateEmit, change: changeEmit } = wrapper.emitted();
         expect(startEmit).toHaveLength(1);
         expect(updateEmit).toHaveLength(1);
@@ -419,7 +417,7 @@ describe("draggable.vue with multidrag plugin", () => {
       });
     });
 
-    describe("when drop from other (add)", () => {
+    describe('when drop from other (add)', () => {
       /** @type {HTMLElement[]} */
       let newElements;
 
@@ -444,11 +442,11 @@ describe("draggable.vue with multidrag plugin", () => {
         await Vue.nextTick();
       });
 
-      it("should added", () => {
-        expect(vm.list).toEqual(["a", "b", "c", "d", "x", "y"]);
+      it('should added', () => {
+        expect(vm.list).toEqual(['a', 'b', 'c', 'd', 'x', 'y']);
       });
 
-      it("should send events", () => {
+      it('should send events', () => {
         const { add: addEmit, change: changeEmit } = wrapper.emitted();
         expect(addEmit).toHaveLength(1);
         expect(changeEmit).toHaveLength(2);

--- a/tests/unit/vuedraggable.multidrag.spec.js
+++ b/tests/unit/vuedraggable.multidrag.spec.js
@@ -85,4 +85,43 @@ describe("draggable.vue with multidrag plugin", () => {
       expect(console.warn).not.toBeCalled();
     });
   });
+
+  describe("should have props", () => {
+    const { props } = create({
+      propsData: {
+        multiDrag: true,
+        selectedClass: 'selected',
+      },
+    });
+
+    test.each([
+      [
+        "multiDrag",
+        {
+          type: Boolean,
+          required: false,
+          default: false,
+        },
+      ],
+      [
+        "multiDragKey",
+        {
+          type: String,
+          required: false,
+          default: null,
+        },
+      ],
+      [
+        "selectedClass",
+        {
+          type: String,
+          required: false,
+          default: null,
+        },
+      ],
+    ])("%s equal to %o", (name, value) => {
+      const propsValue = props[name];
+      expect(propsValue).toEqual(value);
+    });
+  });
 });

--- a/tests/unit/vuedraggable.multidrag.spec.js
+++ b/tests/unit/vuedraggable.multidrag.spec.js
@@ -20,12 +20,31 @@ function resetMocks() {
   SortableFake.option.mockClear();
 }
 
+function create(options) {
+  const { propsData: { items = [] } } = options;
+  const opts = Object.assign({
+    attrs: {
+      sortableOption: "value",
+      "to-be-camelized": true,
+    },
+    slots: {
+      default: items.map((item) => `<div>${item}</div>`),
+      header: "<header/>",
+      footer: "<footer/>",
+    },
+  }, options);
+  const wrapper = shallowMount(draggable, opts);
+  const { vm, element } = wrapper;
+  const { $options: { props } } = vm;
+  return { wrapper, vm, props, element };
+}
+
 describe("draggable.vue with multidrag plugin", () => {
   beforeEach(() => {
     resetMocks();
   });
 
-  describe("when initialized with incorrect props", () => {
+  describe("when initialized", () => {
     const { error } = console;
     const { warn } = console;
 
@@ -39,18 +58,31 @@ describe("draggable.vue with multidrag plugin", () => {
       console.warn = warn;
     });
 
-    it("warns when multiDrag is true but selectedClass is not set", () => {
-      const wrapper = shallowMount(draggable, {
+    describe("with incorrect props", () => {
+      it("warns when multiDrag is true but selectedClass is not set", () => {
+        shallowMount(draggable, {
+          propsData: {
+            multiDrag: true,
+          },
+          slots: {
+            default: "",
+          },
+        });
+        expect(console.warn).toBeCalledWith(
+          "selected-class must be set when multi-drag mode. See https://github.com/SortableJS/Sortable/wiki/Dragging-Multiple-Items-in-Sortable#enable-multi-drag"
+        );
+      });
+    });
+
+    it("instantiate without error", () => {
+      const { wrapper } = create({
         propsData: {
           multiDrag: true,
-        },
-        slots: {
-          default: "",
+          selectedClass: 'selected',
         },
       });
-      expect(console.warn).toBeCalledWith(
-        "selected-class must be set when multi-drag mode. See https://github.com/SortableJS/Sortable/wiki/Dragging-Multiple-Items-in-Sortable#enable-multi-drag"
-      );
+      expect(wrapper).not.toBeUndefined();
+      expect(console.warn).not.toBeCalled();
     });
   });
 });

--- a/tests/unit/vuedraggable.multidrag.spec.js
+++ b/tests/unit/vuedraggable.multidrag.spec.js
@@ -316,10 +316,17 @@ describe('draggable.vue with multidrag plugin', () => {
       });
 
       it('should send events', () => {
+        const expectedEvents = {
+          moved: [
+            { element: 'a', oldIndex: 0, newIndex: 2 },
+            { element: 'b', oldIndex: 1, newIndex: 3 }
+          ]
+        };
         const { start: startEmit, update: updateEmit, change: changeEmit } = wrapper.emitted();
         expect(startEmit).toHaveLength(1);
         expect(updateEmit).toHaveLength(1);
-        expect(changeEmit).toHaveLength(2);
+        expect(changeEmit).toHaveLength(1);
+        expect(changeEmit).toEqual([[expectedEvents]]);
       });
     });
 
@@ -363,10 +370,17 @@ describe('draggable.vue with multidrag plugin', () => {
       });
 
       it('should send events', () => {
+        const expectedEvents = {
+          moved: [
+            { element: 'a', oldIndex: 0, newIndex: 2 },
+            { element: 'b', oldIndex: 1, newIndex: 3 }
+          ]
+        };
         const { start: startEmit, update: updateEmit, change: changeEmit } = wrapper.emitted();
         expect(startEmit).toHaveLength(1);
         expect(updateEmit).toHaveLength(1);
-        expect(changeEmit).toHaveLength(2);
+        expect(changeEmit).toHaveLength(1);
+        expect(changeEmit).toEqual([[expectedEvents]]);
       });
     });
 
@@ -410,10 +424,17 @@ describe('draggable.vue with multidrag plugin', () => {
       });
 
       it('should send events', () => {
+        const expectedEvents = {
+          moved: [
+            { element: 'b', oldIndex: 1, newIndex: 0 },
+            { element: 'd', oldIndex: 3, newIndex: 1 }
+          ]
+        };
         const { start: startEmit, update: updateEmit, change: changeEmit } = wrapper.emitted();
         expect(startEmit).toHaveLength(1);
         expect(updateEmit).toHaveLength(1);
-        expect(changeEmit).toHaveLength(2);
+        expect(changeEmit).toHaveLength(1);
+        expect(changeEmit).toEqual([[expectedEvents]]);
       });
     });
 

--- a/tests/unit/vuedraggable.multidrag.spec.js
+++ b/tests/unit/vuedraggable.multidrag.spec.js
@@ -1,34 +1,20 @@
 import { mount, shallowMount } from "@vue/test-utils";
 import Sortable from "sortablejs";
 
-jest.genMockFromModule("sortablejs");
-jest.mock("sortablejs");
-const SortableFake = {
-  destroy: jest.fn(),
-  option: jest.fn(),
-};
-Sortable.mockImplementation(() => SortableFake);
-
 import draggable from "@/vuedraggable";
 import Vue from "vue";
 import Fake from "./helper/FakeComponent.js";
 import FakeFunctional from "./helper/FakeFunctionalComponent.js";
 
-function resetMocks() {
-  Sortable.mockClear();
-  SortableFake.destroy.mockClear();
-  SortableFake.option.mockClear();
-}
-
 function create(options) {
-  const { propsData: { items = [] } } = options;
+  const { propsData: { list: items = [] } } = options;
   const opts = Object.assign({
     attrs: {
       sortableOption: "value",
       "to-be-camelized": true,
     },
     slots: {
-      default: items.map((item) => `<div>${item}</div>`),
+      default: items.map((item) => `<div class="item">${item}</div>`),
       header: "<header/>",
       footer: "<footer/>",
     },
@@ -40,10 +26,6 @@ function create(options) {
 }
 
 describe("draggable.vue with multidrag plugin", () => {
-  beforeEach(() => {
-    resetMocks();
-  });
-
   describe("when initialized", () => {
     const { error } = console;
     const { warn } = console;

--- a/tests/unit/vuedraggable.multidrag.spec.js
+++ b/tests/unit/vuedraggable.multidrag.spec.js
@@ -106,4 +106,100 @@ describe("draggable.vue with multidrag plugin", () => {
       expect(propsValue).toEqual(value);
     });
   });
+
+  describe("item select and deselect", () => {
+    let wrapper;
+    let vm;
+    const { addEventListener: originalAddEventListener, removeEventListener: originalRemoveEventListener } = document;
+
+    beforeEach(() => {
+      // event listener delegation hack
+      document.addEventListener = (type, listener) => {
+        originalAddEventListener.call(document, type, listener);
+        if (wrapper) {
+          wrapper.element.addEventListener(type, listener);
+        }
+      };
+      document.removeEventListener = (type, listener) => {
+        originalRemoveEventListener.call(document, type, listener);
+        if (wrapper) {
+          wrapper.element.removeEventListener(type, listener);
+        }
+      };
+      // component
+      const items = ["a", "b", "c", "d"];
+      const { wrapper: _w, vm: _v } = create({
+        propsData: {
+          list: items,
+          multiDrag: true,
+          selectedClass: 'selected',
+        },
+      });
+      wrapper = _w;
+      vm = _v;
+    });
+
+    afterEach(() => {
+      document.addEventListener = originalAddEventListener;
+      document.removeEventListener = originalRemoveEventListener;
+    });
+
+    it("should be selected", async () => {
+      const wrapperItems = wrapper.findAll('.item');
+      const item1 = wrapperItems.at(0);
+      const item2 = wrapperItems.at(wrapperItems.length - 1);
+
+      expect(item1.element.matches('.selected')).toBe(false);
+      expect(item2.element.matches('.selected')).toBe(false);
+
+      // select first item
+      // simulate mouse event
+      await item1.trigger('mousedown').then(() => item1.trigger('mouseup'));
+      expect(item1.element.matches('.selected')).toBe(true);
+
+      // select second item
+      // simulate mouse event
+      await item2.trigger('mousedown').then(() => item2.trigger('mouseup'));
+      expect(item2.element.matches('.selected')).toBe(true);
+
+      // check emit event
+      const { select: selectEmit } = wrapper.emitted();
+      expect(selectEmit).not.toBeUndefined();
+      expect(selectEmit).toHaveLength(2);
+      const [[emitEvent1], [emitEvent2]] = selectEmit;
+      expect(emitEvent1.items).toEqual([item1.element]);
+      expect(emitEvent2.items).toEqual([item1.element, item2.element]);
+    });
+
+    it("should be deselected", async () => {
+      const wrapperItems = wrapper.findAll('.item');
+      const item1 = wrapperItems.at(0);
+      const item2 = wrapperItems.at(wrapperItems.length - 1);
+
+      // select items for deselect
+      Sortable.utils.select(item1.element);
+      Sortable.utils.select(item2.element);
+
+      expect(item1.element.matches('.selected')).toBe(true);
+      expect(item2.element.matches('.selected')).toBe(true);
+
+      // deselect first item
+      // simulate mouse event
+      await item1.trigger('mousedown').then(() => item1.trigger('mouseup'));
+      expect(item1.element.matches('.selected')).toBe(false);
+
+      // deselect second item
+      // simulate mouse event
+      await item2.trigger('mousedown').then(() => item2.trigger('mouseup'));
+      expect(item2.element.matches('.selected')).toBe(false);
+
+      // check emit event
+      const { deselect: deselectEmit } = wrapper.emitted();
+      expect(deselectEmit).not.toBeUndefined();
+      expect(deselectEmit).toHaveLength(2);
+      const [[emitEvent1], [emitEvent2]] = deselectEmit;
+      expect(emitEvent1.items).toEqual([item2.element]);
+      expect(emitEvent2.items).toEqual([]);
+    });
+  });
 });

--- a/tests/unit/vuedraggable.multidrag.spec.js
+++ b/tests/unit/vuedraggable.multidrag.spec.js
@@ -224,14 +224,14 @@ describe("draggable.vue with multidrag plugin", () => {
   describe("multi item drag and drop", () => {
     /** @type {import("@vue/test-utils").Wrapper<Vue>} */
     let wrapper;
+    /** @type {import("@vue/test-utils").WrapperArray<Vue>} */
+    let wrapperItems;
     /** @type {Vue} */
     let vm;
     /** @type {jest.SpyInstance} */
     let addEventListenerMock;
     /** @type {jest.SpyInstance} */
     let removeEventListenerMock;
-    /** @type {string[]} */
-    let items;
     /** @type {(event: Event) => void} */
     let onStart;
     /** @type {(event: Event) => void} */
@@ -247,7 +247,7 @@ describe("draggable.vue with multidrag plugin", () => {
       });
 
       // component
-      items = ["a", "b", "c", "d"];
+      const items = ["a", "b", "c", "d"];
       const { wrapper: _w, vm: _v } = create({
         propsData: {
           list: items,
@@ -257,6 +257,7 @@ describe("draggable.vue with multidrag plugin", () => {
       });
       wrapper = _w;
       vm = _v;
+      wrapperItems = wrapper.findAll('.item');
 
       onStart = vm._sortable.options.onStart;
       onUpdate = vm._sortable.options.onUpdate;
@@ -269,7 +270,6 @@ describe("draggable.vue with multidrag plugin", () => {
 
     describe("should work", () => {
       it("when drop first and second into last", async () => {
-        const wrapperItems = wrapper.findAll('.item');
         const item1 = wrapperItems.at(0);
         const item2 = wrapperItems.at(1);
   
@@ -304,6 +304,91 @@ describe("draggable.vue with multidrag plugin", () => {
 
         // check items order
         expect(vm.list).toEqual(["c", "d", "a", "b"]);
+
+        // check emit event
+        const { start: startEmit, update: updateEmit } = wrapper.emitted();
+        expect(startEmit).not.toBeUndefined();
+        expect(updateEmit).not.toBeUndefined();
+      });
+
+      it("when drop second and first into last", async () => {
+        const item1 = wrapperItems.at(0);
+        const item2 = wrapperItems.at(1);
+  
+        // start drag from first item
+        const startEvent = {
+          item: item2.element,
+          items: [item2.element, item1.element],
+        };
+        onStart(startEvent);
+        await Vue.nextTick();
+
+        // drop to last item
+        const updateEvent = {
+          from: wrapper.element,
+          newIndex: 3,
+          newDraggableIndex: 3,
+          oldIndex: 1,
+          oldDraggableIndex: 1,
+          item: item1.element,
+          items: [item2.element, item1.element],
+          oldIndicies: [
+            { multiDragElement: item2.element, index: 2 },
+            { multiDragElement: item1.element, index: 1 },
+          ],
+          newIndicies: [
+            { multiDragElement: item2.element, index: 4 },
+            { multiDragElement: item1.element, index: 3 },
+          ],
+        };
+        onUpdate(updateEvent);
+        await Vue.nextTick();
+
+        // check items order
+        expect(vm.list).toEqual(["c", "d", "a", "b"]);
+
+        // check emit event
+        const { start: startEmit, update: updateEmit } = wrapper.emitted();
+        expect(startEmit).not.toBeUndefined();
+        expect(updateEmit).not.toBeUndefined();
+      });
+
+
+      it("when drop second and last into first", async () => {
+        const item1 = wrapperItems.at(1);
+        const item2 = wrapperItems.at(3);
+  
+        // start drag from first item
+        const startEvent = {
+          item: item1.element,
+          items: [item1.element, item2.element],
+        };
+        onStart(startEvent);
+        await Vue.nextTick();
+
+        // drop to last item
+        const updateEvent = {
+          from: wrapper.element,
+          newIndex: 1,
+          newDraggableIndex: 1,
+          oldIndex: 2,
+          oldDraggableIndex: 2,
+          item: item1.element,
+          items: [item2.element, item1.element],
+          oldIndicies: [
+            { multiDragElement: item1.element, index: 2 },
+            { multiDragElement: item2.element, index: 4 },
+          ],
+          newIndicies: [
+            { multiDragElement: item1.element, index: 1 },
+            { multiDragElement: item2.element, index: 2 },
+          ],
+        };
+        onUpdate(updateEvent);
+        await Vue.nextTick();
+
+        // check items order
+        expect(vm.list).toEqual(["b", "d", "a", "c"]);
 
         // check emit event
         const { start: startEmit, update: updateEmit } = wrapper.emitted();

--- a/tests/unit/vuedraggable.multidrag.spec.js
+++ b/tests/unit/vuedraggable.multidrag.spec.js
@@ -468,9 +468,16 @@ describe('draggable.vue with multidrag plugin', () => {
       });
 
       it('should send events', () => {
+        const expectedEvents = {
+          added: [
+            { element: 'x', newIndex: 4 },
+            { element: 'y', newIndex: 5 }
+          ]
+        };
         const { add: addEmit, change: changeEmit } = wrapper.emitted();
         expect(addEmit).toHaveLength(1);
-        expect(changeEmit).toHaveLength(2);
+        expect(changeEmit).toHaveLength(1);
+        expect(changeEmit).toEqual([[expectedEvents]]);
       });
     });
 
@@ -510,9 +517,16 @@ describe('draggable.vue with multidrag plugin', () => {
       });
 
       it('should send events', () => {
+        const expectedEvents = {
+          removed: [
+            { element: 'a', oldIndex: 0 },
+            { element: 'c', oldIndex: 2 }
+          ]
+        };
         const { remove: removeEmit, change: changeEmit } = wrapper.emitted();
         expect(removeEmit).toHaveLength(1);
-        expect(changeEmit).toHaveLength(2);
+        expect(changeEmit).toHaveLength(1);
+        expect(changeEmit).toEqual([[expectedEvents]]);
       });
     });
   });

--- a/tests/unit/vuedraggable.multidrag.spec.js
+++ b/tests/unit/vuedraggable.multidrag.spec.js
@@ -1,0 +1,27 @@
+import { mount, shallowMount } from "@vue/test-utils";
+import Sortable from "sortablejs";
+
+jest.genMockFromModule("sortablejs");
+jest.mock("sortablejs");
+const SortableFake = {
+  destroy: jest.fn(),
+  option: jest.fn(),
+};
+Sortable.mockImplementation(() => SortableFake);
+
+import draggable from "@/vuedraggable";
+import Vue from "vue";
+import Fake from "./helper/FakeComponent.js";
+import FakeFunctional from "./helper/FakeFunctionalComponent.js";
+
+function resetMocks() {
+  Sortable.mockClear();
+  SortableFake.destroy.mockClear();
+  SortableFake.option.mockClear();
+}
+
+describe("draggable.vue with multidrag plugin", () => {
+  beforeEach(() => {
+    resetMocks();
+  });
+});

--- a/tests/unit/vuedraggable.multidrag.spec.js
+++ b/tests/unit/vuedraggable.multidrag.spec.js
@@ -24,4 +24,33 @@ describe("draggable.vue with multidrag plugin", () => {
   beforeEach(() => {
     resetMocks();
   });
+
+  describe("when initialized with incorrect props", () => {
+    const { error } = console;
+    const { warn } = console;
+
+    beforeEach(() => {
+      console.error = jest.fn();
+      console.warn = jest.fn();
+    });
+
+    afterEach(() => {
+      console.error = error;
+      console.warn = warn;
+    });
+
+    it("warns when multiDrag is true but selectedClass is not set", () => {
+      const wrapper = shallowMount(draggable, {
+        propsData: {
+          multiDrag: true,
+        },
+        slots: {
+          default: "",
+        },
+      });
+      expect(console.warn).toBeCalledWith(
+        "selected-class must be set when multi-drag mode. See https://github.com/SortableJS/Sortable/wiki/Dragging-Multiple-Items-in-Sortable#enable-multi-drag"
+      );
+    });
+  });
 });

--- a/tests/unit/vuedraggable.multidrag.spec.js
+++ b/tests/unit/vuedraggable.multidrag.spec.js
@@ -52,31 +52,16 @@ describe('draggable.vue with multidrag plugin', () => {
       console.warn = warn;
     });
 
-    describe('with incorrect props', () => {
-      it('warns when multiDrag is true but selectedClass is not set', () => {
-        shallowMount(draggable, {
-          propsData: {
-            multiDrag: true,
-          },
-          slots: {
-            default: "",
-          },
-        });
-        expect(console.warn).toBeCalledWith(
-          'selected-class must be set when multi-drag mode. See https://github.com/SortableJS/Sortable/wiki/Dragging-Multiple-Items-in-Sortable#enable-multi-drag'
-        );
-      });
-    });
-
     it('instantiate without error', () => {
-      const { wrapper } = create({
+      const { wrapper, vm } = create({
         propsData: {
           multiDrag: true,
           selectedClass: 'selected',
         },
       });
-      expect(wrapper).not.toBeUndefined();
       expect(console.warn).not.toBeCalled();
+      expect(wrapper).not.toBeUndefined();
+      expect(vm._sortable.multiDrag).not.toBeUndefined();
     });
   });
 

--- a/tests/unit/vuedraggable.multidrag.spec.js
+++ b/tests/unit/vuedraggable.multidrag.spec.js
@@ -240,6 +240,10 @@ describe("draggable.vue with multidrag plugin", () => {
     let onStart;
     /** @type {(event: Event) => void} */
     let onUpdate;
+    /** @type {(event: Event) => void} */
+    let onAdd;
+    /** @type {(event: Event) => void} */
+    let onRemove;
 
     beforeEach(() => {
       // event listener delegation hack
@@ -265,6 +269,8 @@ describe("draggable.vue with multidrag plugin", () => {
 
       onStart = vm._sortable.options.onStart;
       onUpdate = vm._sortable.options.onUpdate;
+      onAdd = vm._sortable.options.onAdd;
+      onRemove = vm._sortable.options.onRemove;
     });
 
     afterEach(() => {
@@ -409,6 +415,42 @@ describe("draggable.vue with multidrag plugin", () => {
         const { start: startEmit, update: updateEmit, change: changeEmit } = wrapper.emitted();
         expect(startEmit).toHaveLength(1);
         expect(updateEmit).toHaveLength(1);
+        expect(changeEmit).toHaveLength(2);
+      });
+    });
+
+    describe("when drop from other (add)", () => {
+      /** @type {HTMLElement[]} */
+      let newElements;
+
+      beforeEach(async () => {
+        const newItems = ['x', 'y'];
+        newElements = newItems.map((item) => {
+          const element = document.createElement('div');
+          element.appendChild(document.createTextNode(item));
+          return element;
+        });
+        const newElement = newElements[0];
+        newElement._underlying_vm_multidrag_ = newItems;
+
+        // drop after last item
+        const addEvent = {
+          newIndex: 5,
+          newDraggableIndex: 5,
+          item: newElement,
+          items: newElements,
+        };
+        onAdd(addEvent);
+        await Vue.nextTick();
+      });
+
+      it("should added", () => {
+        expect(vm.list).toEqual(["a", "b", "c", "d", "x", "y"]);
+      });
+
+      it("should send events", () => {
+        const { add: addEmit, change: changeEmit } = wrapper.emitted();
+        expect(addEmit).toHaveLength(1);
         expect(changeEmit).toHaveLength(2);
       });
     });

--- a/tests/unit/vuedraggable.multidrag.spec.js
+++ b/tests/unit/vuedraggable.multidrag.spec.js
@@ -452,5 +452,47 @@ describe('draggable.vue with multidrag plugin', () => {
         expect(changeEmit).toHaveLength(2);
       });
     });
+
+    describe('when drop to other (remove)', () => {
+      beforeEach(async () => {
+        item1 = wrapperItems.at(0);
+        item2 = wrapperItems.at(2);
+  
+        // start drag from first item
+        const startEvent = {
+          item: item1.element,
+          items: [item1.element, item2.element],
+        };
+        onStart(startEvent);
+        await Vue.nextTick();
+
+        wrapper.element.removeChild(item1.element);
+        wrapper.element.removeChild(item2.element);
+
+        // drop after last item
+        const removeEvent = {
+          newIndex: 5,
+          newDraggableIndex: 5,
+          item: item1,
+          items: [item1, item2],
+          oldIndicies: [
+            { multiDragElement: item1.element, index: 1 },
+            { multiDragElement: item2.element, index: 3 },
+          ],
+        };
+        onRemove(removeEvent);
+        await Vue.nextTick();
+      });
+
+      it('should removed', () => {
+        expect(vm.list).toEqual(['b', 'd']);
+      });
+
+      it('should send events', () => {
+        const { remove: removeEmit, change: changeEmit } = wrapper.emitted();
+        expect(removeEmit).toHaveLength(1);
+        expect(changeEmit).toHaveLength(2);
+      });
+    });
   });
 });


### PR DESCRIPTION
For #104, #536, and #649 :rocket: 

#744 is superseded with:
 * Example included
 * Unit test included :tada:
 * implementation is more clearer then #744

