### PR TITLE
Refactored isTransitionName

### DIFF
--- a/src/vuedraggable.js
+++ b/src/vuedraggable.js
@@ -41,7 +41,7 @@ function delegateAndEmit(evtName) {
 }
 
 function isTransitionName(name) {
-  return ["transition-group", "TransitionGroup"].includes(name);
+  return ["transition-group", "TransitionGroup"].indexOf(name) > -1;
 }
 
 function isTransition(slots) {


### PR DESCRIPTION
Replaced `includes` with `indexOf` call in isTransitionName. Noticed the includes call was causing issues in IE11 when used with polyfill.io and certain Array-related polyfills. The proposed change should be more compatible under different scenarios, since indexOf is natively supported in IE11, unlike includes.