### PR TITLE
Correct pluralisation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ New in version 2.19
 
 Sortable options can be set directly as vue.draggable props since version 2.19.
 
-This means that all [sortable option](https://github.com/RubaXa/Sortable#options) are valid sortable props with the notable exception of all the method starting by "on" as draggable component expose the same API via events.
+This means that all [sortable options](https://github.com/RubaXa/Sortable#options) are valid sortable props with the notable exception of all the method starting by "on" as draggable component expose the same API via events.
 
 kebab-case propery are supported: for example `ghost-class` props will be converted to `ghostClass` sortable option.
 


### PR DESCRIPTION
A minor update to update the `sortable option` link in the "All sortable options"  section to be the plural, `sortable options`.