### PR TITLE
Update Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ Vue component (Vue.js 2.0) or directive (Vue.js 1.0) allowing drag-and-drop and 
 Based on and offering all features of [Sortable.js](https://github.com/RubaXa/Sortable)
 
 
-## For Vue 3
-   See [vue.draggable.next](https://github.com/SortableJS/vue.draggable.next)
+> For Vue 3, see [vue.draggable.next](https://github.com/SortableJS/vue.draggable.next)
 
 ## Demo
 


### PR DESCRIPTION
Changelog:

- changed the way Vue 3 integration information pointer is visually presented in the file.

Reasoning:

I found it quite confusing to have a header which said `FOR VUE 3` because my first thought was that this is for Vue 3, and then I noticed the little paragraph link below, which I think was well-hidden. I think this simple styling change makes it a bit easier on the eyes and the brain.