### PR TITLE
fix: Determine whether Vue is Window sub -attribute

### DIFF
--- a/src/vuedraggable.js
+++ b/src/vuedraggable.js
@@ -478,7 +478,7 @@ const draggableComponent = {
   }
 };
 
-if (typeof window !== "undefined" && "Vue" in window) {
+if (typeof window !== "undefined" && "Vue" in window && window.Vue !== undefined) {
   window.Vue.component("draggable", draggableComponent);
 }
 


### PR DESCRIPTION
https://github.com/SortableJS/Vue.Draggable/issues/1168#issue-1433973168   When Vue is on the prototype chain of Window, `"Vue" in window` is true. You need to judge window.vue is not undefined.