### PR TITLE
Fix: nested-with-vmodel example not really trigger vuex actions

### DIFF
--- a/example/components/nested-with-vmodel.vue
+++ b/example/components/nested-with-vmodel.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="justify-content-between row">
-    <nested-test class="col-8" v-model="elements" />
-    <raw-displayer class="col-4" :title="'Vuex Store'" :value="elements" />
+    <nested-test class="col-8" v-model="list" />
+    <raw-displayer class="col-4" :title="'Vuex Store'" :value="list" />
   </div>
 </template>
 
@@ -17,14 +17,17 @@ export default {
     NestedTest,
     rawDisplayer
   },
-  computed: {
-    elements: {
-      get() {
-        return this.$store.state.nested.elements;
+  data: function() {
+    return {
+      list: this.$store.state.nested.elements
+    };
+  },
+  watch: {
+    list: {
+      handler: function(val) {
+        this.$store.dispatch("nested/updateElements", val);
       },
-      set(value) {
-        this.$store.dispatch("nested/updateElements", value);
-      }
+      deep: true
     }
   },
   methods: {}


### PR DESCRIPTION
Regarding the example of nested-with-vmodel, I have noticed that using computed sometimes does not trigger the modification of data in Vuex. Even if it appears that the data has changed on the page, it does not seem to be caused by Vuex behavior. This may be due to my limited knowledge of Vue, but I believe it is the data reference behavior of computed itself.

It is important to note that only when the first layer of data in the nested-test component changes will it trigger the set of elements. 