### PR TITLE
Issue 1213: Fix accessing nextSibling property in insertNodeAt function

### DIFF
--- a/src/util/helper.js
+++ b/src/util/helper.js
@@ -29,7 +29,7 @@ function insertNodeAt(fatherNode, node, position) {
   const refNode =
     position === 0
       ? fatherNode.children[0]
-      : fatherNode.children[position - 1].nextSibling;
+      : fatherNode.children[position - 1]?.nextSibling;
   fatherNode.insertBefore(node, refNode);
 }
 

--- a/tests/unit/util/helper.spec.js
+++ b/tests/unit/util/helper.spec.js
@@ -1,4 +1,4 @@
-import { camelize, console } from "@/util/helper";
+import { camelize, console, insertNodeAt } from "@/util/helper";
 
 describe("camelize", () => {
   test.each([
@@ -30,4 +30,27 @@ describe("console", () => {
       expect(typeof actual).toEqual("function");
     }
   )
+});
+
+describe('insertNodeAt', () => {
+  const node = document.createElement('div');
+  const nextSibling = document.createElement('div');
+  const child = { nextSibling };
+  const mockInsertBefore = jest.fn();
+  const fatherNode = {
+    insertBefore: mockInsertBefore,
+    children: [child]
+  }
+  test('Inserts node at 0 position', () => {
+    insertNodeAt(fatherNode, node, 0);
+    expect(mockInsertBefore).toHaveBeenCalledWith(node, child);
+  })
+  test('Inserts node at 1 position', () => {
+    insertNodeAt(fatherNode, node, 1);
+    expect(mockInsertBefore).toHaveBeenCalledWith(node, nextSibling);
+  })
+  test("Inserts node at the end of node's child nodes", () => {
+    insertNodeAt(fatherNode, node, 2);
+    expect(mockInsertBefore).toHaveBeenCalledWith(node, undefined);
+  })
 });


### PR DESCRIPTION
Fix for issue https://github.com/SortableJS/Vue.Draggable/issues/1213 (problem and solution are already explained there)