### PR TITLE
fix: filter out comment node to prevent sorting issue with collapsibl…

### DIFF
--- a/src/vuedraggable.js
+++ b/src/vuedraggable.js
@@ -11,7 +11,10 @@ function buildAttribute(object, propName, value) {
 }
 
 function computeVmIndex(vnodes, element) {
-  return vnodes.map(elt => elt.elm).indexOf(element);
+  return vnodes
+  .map(elt => elt.elm)
+  .filter(elt => elt.nodeName !== '#comment')
+  .indexOf(element);
 }
 
 function computeIndexes(slots, children, isTransition, footerOffset) {
@@ -19,7 +22,7 @@ function computeIndexes(slots, children, isTransition, footerOffset) {
     return [];
   }
 
-  const elmFromNodes = slots.map(elt => elt.elm);
+  const elmFromNodes = slots.map(elt => elt.elm).filter(elt => elt.nodeName !== '#comment');
   const footerIndex = children.length - footerOffset;
   const rawIndexes = [...children].map((elt, idx) =>
     idx >= footerIndex ? elmFromNodes.length : elmFromNodes.indexOf(elt)


### PR DESCRIPTION
**Issue**
When a table has collapsible items, or the table row has dynamic items depending on vue directive v-if/v-show,
the dragging behavior is wired and the sorting order is wrong.

**Root Cause**
In addition to the actual rows, the rows with v-if directive false will be comment nodes which causes the dragging target is wrong. 

**Solution**
Filter out comment nodes to avoid the bug
